### PR TITLE
Use Mautic's repo for FOS Oauth bundle that supports PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
   "repositories": [
     {
       "type": "git",
-      "url": "https://github.com/dennisameling/FOSOAuthServerBundle.git"
+      "url": "https://github.com/mautic/FOSOAuthServerBundle.git"
     }
   ],
   "conflict": {


### PR DESCRIPTION
I'm getting this error when I try to install Mautic via this recommended project on a server with PHP 8.0:
```
composer create-project mautic/recommended-project:^4.4 html --no-interaction
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Creating a "mautic/recommended-project:^4.4" project at "./html"
Info from https://repo.packagist.org: #StandWithUkraine
Installing mautic/recommended-project (4.4.0)
As there is no 'unzip' nor '7z' command installed zip files are being unpacked using the PHP zip extension.
This may cause invalid reports of corrupted archives. Besides, any UNIX permissions (e.g. executable) defined in the archives will be lost.
Installing 'unzip' or '7z' (21.01+) may remediate them.
  - Installing mautic/recommended-project (4.4.0): Extracting archive
Created project in /var/www/html/html
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - friendsofsymfony/oauth-server-bundle dev-doctrine-fix requires php ^5.5|^7.0 -> your php version (8.0.20) does not satisfy that requirement.
    - mautic/core-lib 4.4.0 requires friendsofsymfony/oauth-server-bundle dev-doctrine-fix -> satisfiable by friendsofsymfony/oauth-server-bundle[dev-doctrine-fix].
    - Root composer.json requires mautic/core-lib 4.4.0 -> satisfiable by mautic/core-lib[4.4.0].
```

I noticed that it this repo is still using the fork of `friendsofsymfony/oauth-server-bundle` from Dennis but Mautic 4.4 is using the one from Mautic:

https://github.com/mautic/mautic/blob/4.4/app/composer.json#L115

So I hope this will fix it 🤞 