### PR TITLE
add missing forked repos

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,14 @@
     {
       "type": "git",
       "url": "https://github.com/mautic/FOSOAuthServerBundle.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/mautic/SpBundle.git"
+    },
+    {
+      "type": "git",
+      "url": "https://github.com/mautic/SymfonyBridgeBundle.git"
     }
   ],
   "conflict": {


### PR DESCRIPTION
in 5.x some repos were forked and added to the [composer.json file](https://github.com/mautic/mautic/blob/5.x/app/composer.json#L112-L125), that were not yet added here.

This breaks installing 5.x with the recommended project.

This PR fixes this