### PR TITLE
Use existing PHP process/version to run post update command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
     ],
     "npm-ci": "npm ci --prefer-offline --no-audit",
     "npx-patch-package": "npx patch-package",
-    "generate-assets": "php bin/console mautic:assets:generate"
+    "generate-assets": "@php bin/console mautic:assets:generate"
   },
   "extra": {
     "mautic-scaffold": {


### PR DESCRIPTION
If you run the install command with a different executable, the post update command will currently still run with the default PHP executable, which can cause errors if the versions are different. This corrects that to run with the same version.

Example:

```bash
php8.1 composer create-project mautic/recommended-project:^5 /srv/mautic --no-interaction
```

https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts