### PR TITLE
Refactor: Change docroot to public to align with Symfony's best practice structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ This project supports PHP 8.2 as the minimum version (see [Mautic requirements](
 To prevent this, you can specify the PHP version in the `config` section of `composer.json` by adding the following code:
 ```json
 "config": {
-    "sort-packages": true,
     "platform": {
         "php": "8.2"
     }

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Follow the steps below to update your core files.
 2. Run `git diff` to determine if any of the scaffolding files have changed.
    Review the files for any changes and restore any customizations to
   `.htaccess` or others.
-1. Commit everything all together in a single commit, so `public/` will remain in
+3. Commit everything all together in a single commit, so `public/` will remain in
    sync with the `core` when checking out branches or running `git bisect`.
-1. In the event that there are non-trivial conflicts in step 2, you may wish
+4. In the event that there are non-trivial conflicts in step 2, you may wish
    to perform these steps on a branch, and use `git merge` to combine the
    updated core files with your customized files. This facilitates the use
    of a [three-way merge tool such as kdiff3](http://www.gitshah.com/2010/12/how-to-setup-kdiff-as-diff-tool-for-git.html). This setup is not necessary if your changes are simple;
@@ -132,27 +132,28 @@ composer config platform.php 8.2
 
 ### How do I use another folder than docroot as webroot?
 
-By default the composer.json file is configures to put all Mautic core, plugin and theme files in the `public/` folder.  
-It is possible to change this folder to your own needs.
+By default the composer.json file is configures to put all Mautic core, plugin and theme files in the `public/` directory.  
+It is possible to change this directory to your own needs.
 
-In following examples, we will change `public/` into `public_html/`.
+In following examples, we will change `public/` into `docroot/`.
 
 #### New installations
 
-* Run the `create-project` command without installing  
+* Run the `create-project` command without installing
   ```bash
   composer create-project mautic/recommended-project:^7.0 some-dir --no-interaction --no-install
   ```
-* Do a find and replace in the `composer.json` file to change `public/` into `public_html/`.
+* Do a find and replace in the `composer.json` file to change `public/` into `docroot/`.
 * Review the changes in the `composer.json` file to ensure there are no unintentional replacements.
 * Run `composer install` to install all dependencies in the correct location.
 
 #### Existing installations
 
-* move the `public/` to `public_html/`
+* Move the `public/` to `docroot/`
   ```bash
-  mv public public_html
+  mv public docroot
   ```
-* Do a find and replace in the `composer.json` file to change `public/` into `public_html/`.
-* review the changes in the `composer.json` file to ensure there are no unintentional replacements.
-* run `composer update --lock` to ensure the autoloader is aware of the changed folder.
+* Do a find and replace in the `composer.json` file to change `public/` into `docroot/`.
+* Review the changes in the `composer.json` file to ensure there are no unintentional replacements.
+* Run `composer update --lock` to ensure the autoloader is aware of the changed directory.
+* Ensure that config parameters related to the `media` directory in the `config/local.php` file point to the correct directory (`docroot/media` instead of `public/media`)

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ all files not excluded by the .gitignore file.
 
 When installing the given `composer.json` some tasks are taken care of:
 
-* Mautic will be installed in the `docroot`-directory.
+* Mautic will be installed in the `public/` directory.
 * Autoloader is implemented to use the generated composer autoloader in `vendor/autoload.php`,
-  instead of the one provided by Mautic (`docroot/vendor/autoload.php`).
-* Plugins (packages of type `mautic-plugin`) will be placed in `docroot/plugins/`
-* Themes (packages of type `mautic-theme`) will be placed in `docroot/themes/`
-* Creates `docroot/media`-directory.
+  instead of the one provided by Mautic (`public/vendor/autoload.php`).
+* Plugins (packages of type `mautic-plugin`) will be placed in `public/plugins/`
+* Themes (packages of type `mautic-theme`) will be placed in `public/themes/`
+* Creates `public/media` directory.
 * Creates environment variables based on your .env file. See [.env.example](.env.example).
 
 ## Updating Mautic Core
@@ -56,7 +56,7 @@ Follow the steps below to update your core files.
 2. Run `git diff` to determine if any of the scaffolding files have changed.
    Review the files for any changes and restore any customizations to
   `.htaccess` or others.
-1. Commit everything all together in a single commit, so `docroot` will remain in
+1. Commit everything all together in a single commit, so `public/` will remain in
    sync with the `core` when checking out branches or running `git bisect`.
 1. In the event that there are non-trivial conflicts in step 2, you may wish
    to perform these steps on a branch, and use `git merge` to combine the
@@ -75,7 +75,7 @@ workrounds if a project decides to do it anyway](https://getcomposer.org/doc/faq
 ### Should I commit the scaffolding files?
 
 The [Mautic Composer Scaffold](https://github.com/mautic/core-composer-scaffold) plugin can download the scaffold files (like
-index.php, .htaccess, …) to the docroot/ directory of your project. If you have not customized those files you could choose
+index.php, .htaccess, …) to the `public/` directory of your project. If you have not customized those files you could choose
 to not check them into your version control system (e.g. git). If that is the case for your project it might be
 convenient to automatically run the mautic-scaffold plugin after every install or update of your project. You can
 achieve that by registering `@composer mautic:scaffold` as post-install and post-update command in your composer.json:
@@ -132,10 +132,10 @@ composer config platform.php 8.2
 
 ### How do I use another folder than docroot as webroot?
 
-By default the composer.json file is configures to put all Mautic core, plugin and theme files in the `docroot` folder.  
+By default the composer.json file is configures to put all Mautic core, plugin and theme files in the `public/` folder.  
 It is possible to change this folder to your own needs.
 
-In following examples, we will change `docroot` into `public`.
+In following examples, we will change `public/` into `public_html/`.
 
 #### New installations
 
@@ -143,16 +143,16 @@ In following examples, we will change `docroot` into `public`.
   ```bash
   composer create-project mautic/recommended-project:^7.0 some-dir --no-interaction --no-install
   ```
-* Do a find and replace in the `composer.json` file to change `docroot/` into `public/`.
+* Do a find and replace in the `composer.json` file to change `public/` into `public_html/`.
 * Review the changes in the `composer.json` file to ensure there are no unintentional replacements.
 * Run `composer install` to install all dependencies in the correct location.
 
 #### Existing installations
 
-* move the `docroot/` to `public/`
+* move the `public/` to `public_html/`
   ```bash
-  mv docroot public
+  mv public public_html
   ```
-* Do a find and replace in the `composer.json` file to change `docroot/` into `public/`.
+* Do a find and replace in the `composer.json` file to change `public/` into `public_html/`.
 * review the changes in the `composer.json` file to ensure there are no unintentional replacements.
 * run `composer update --lock` to ensure the autoloader is aware of the changed folder.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ Alternatively, you can run the following command:
 composer config platform.php 8.2
 ```
 
-
-### How do I use another folder than docroot as webroot?
+### How do I use another folder than `public` as webroot?
 
 By default the composer.json file is configures to put all Mautic core, plugin and theme files in the `public/` directory.  
 It is possible to change this directory to your own needs.

--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
   },
   "autoload": {
     "psr-4": {
-      "MauticPlugin\\": "docroot/plugins/"
+      "MauticPlugin\\": "public/plugins/"
     }
   },
   "scripts": {
@@ -129,17 +129,17 @@
   "extra": {
     "mautic-scaffold": {
       "locations": {
-        "web-root": "docroot/"
+        "web-root": "public/"
       }
     },
     "installer-paths": {
-      "docroot/app": [
+      "public/app": [
         "type:mautic-core"
       ],
-      "docroot/plugins/{$name}": [
+      "public/plugins/{$name}": [
         "type:mautic-plugin"
       ],
-      "docroot/themes/{$name}": [
+      "public/themes/{$name}": [
         "type:mautic-theme"
       ]
     },

--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,12 @@
     ],
     "npm-ci": "npm ci --prefer-offline --no-audit",
     "npx-patch-package": "npx patch-package",
-    "generate-assets": "@php bin/console mautic:assets:generate"
+    "generate-assets": "@php bin/console mautic:assets:generate",
+    "migrate-webroot": [
+      "@php -r \"if (!is_dir('docroot')) { echo 'ERROR: Directory docroot/ not found. Already migrated? Exiting.' . PHP_EOL; exit(1); } if (is_dir('public')) { echo 'ERROR: Directory public/ already exists. Already migrated? Exiting.' . PHP_EOL; exit(1); } rename('docroot', 'public');\"",
+      "@php -r \"\\$file='composer.json'; copy(\\$file, \\$file.'.backup'); \\$content = file_get_contents(\\$file); \\$content = preg_replace('/\\\"web-root\\\": \\\"docroot\\//','\\\"web-root\\\": \\\"public/', \\$content); \\$content = preg_replace('/\\\"docroot\\/app\\\": \\[/', '\\\"public/app\\\": [', \\$content); \\$content = preg_replace('/\\\"docroot\\/plugins\\/\\{\\\\\\$name\\}\\\": \\[/', '\\\"public/plugins/{\\\\\\$name}\\\": [', \\$content); \\$content = preg_replace('/\\\"docroot\\/themes\\/\\{\\\\\\$name\\}\\\": \\[/', '\\\"public/themes/{\\\\\\$name}\\\": [', \\$content); file_put_contents(\\$file, \\$content);\"",
+      "@php -r \"\\$file='config/local.php'; copy(\\$file, \\$file.'.backup'); \\$content = file_get_contents(\\$file); \\$content = preg_replace('/(\\'[^\\']+\\'\\s*=>\\s*\\')(.*?)\\/docroot\\/media(.*?\\')/', '\\1\\2/public/media\\3', \\$content); file_put_contents(\\$file, \\$content);\""
+    ]
   },
   "extra": {
     "mautic-scaffold": {


### PR DESCRIPTION
This PR updates the project structure to align with Symfony's best practices by renaming the `docroot` directory to `public`. This change ensures consistency with Symfony's default directory structure, as outlined in the [Symfony Best Practices documentation](https://symfony.com/doc/current/best_practices.html#use-the-default-directory-structure).

Fixes #6 

Changes
- Updated `composer.json` to reference `public` instead of `docroot`.
- Updated `README.md` to replace all references to `docroot` with `public`.

A PR needs to be created in the `mautic/user-documentation` repository to update the Composer installation steps related to the web root for the 6.x version.