### PR TITLE
Switch mautic/core-composer-scaffold from 4.x-dev to 1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   ],
   "require": {
     "composer/installers": "^2.3",
-    "mautic/core-composer-scaffold": "4.x-dev",
+    "mautic/core-composer-scaffold": "1.0.0",
     "mautic/core-lib": "7.x-dev",
     "mautic/core-project-message": "4.x-dev",
     "mautic/grapes-js-builder-bundle": "7.x-dev",


### PR DESCRIPTION
This PR updates the Composer dependency for `mautic/core-composer-scaffold` to use the newly tagged `1.0.0` instead of the `4.x-dev` development branch.

Using the tagged version ensures consistent installs, avoiding potential breaking changes from the dev branch.

https://github.com/mautic/core-composer-scaffold/releases/tag/1.0.0

The `1.0.0` tag was chosen because this dependency doesn't need to be updated with every Mautic release and therefore doesn't have to match Mautic's versioning. Using an independent tag also avoids confusion during Mautic release preparation - if this dependency used a version like `7.0.0-beta`, a release leader could accidentally change it between `7.x-dev` and `7.0.0-beta` while aligning other dependencies, even though this package isn't tagged for every Mautic release. There is also no point in tagging it for every Mautic release if nothing has changed in this package.

Testing steps:
1. Create a new directory
2. Create a `composer.json` file in this directory using the content from [mautic/recommended-project (7.x branch)](https://github.com/mautic/recommended-project/blob/7.x/composer.json)
3. Replace `4.x-dev` with `1.0.0` for `mautic/core-composer-scaffold`
4. Run `composer install` in this directory
4.1. Confirm that the dependency resolves to version `1.0.0`
4.2. Ensure installation completes successfully