### PR TITLE
Assets fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,10 @@
     ],
     "npm-ci": "npm ci --prefer-offline --no-audit",
     "npx-patch-package": "npx patch-package",
-    "generate-assets": "@php bin/console mautic:assets:generate && @php bin/console assets:install --symlink --relative docroot/"
+    "generate-assets": [
+      "@php bin/console mautic:assets:generate",
+      "@php bin/console assets:install --symlink --relative docroot/"
+    ]
   },
   "extra": {
     "public-dir": "docroot",

--- a/composer.json
+++ b/composer.json
@@ -124,9 +124,10 @@
     ],
     "npm-ci": "npm ci --prefer-offline --no-audit",
     "npx-patch-package": "npx patch-package",
-    "generate-assets": "@php bin/console mautic:assets:generate"
+    "generate-assets": "@php bin/console mautic:assets:generate && @php bin/console assets:install --symlink --relative docroot/"
   },
   "extra": {
+    "public-dir": "docroot",
     "mautic-scaffold": {
       "locations": {
         "web-root": "docroot/"


### PR DESCRIPTION
## PR for mautic/recommended-project

| Q                                      | A
| -------------------------------------- | ---
| Bug fix?                               | ✔️
| New feature/enhancement?               | ❌
| Deprecations?                          | ❌
| BC breaks?                             | ❌
| Issue(s) addressed                     | Fixes #6, Fixes #50 (partial)

## Description

This PR adds the `public-dir` setting to composer.json to fix Symfony's `assets:install` command installing assets to the wrong directory.

### The Problem

When running `bin/console assets:install`, Symfony installs bundle assets to `public/` by default. For recommended-project installations where the webroot is `docroot/`, this causes:

- API Platform documentation assets not being accessible
- Other bundle assets (ElFinder, etc.) installed in wrong location

### The Solution

Add `"public-dir": "docroot"` to composer.json's `extra` section. This tells Symfony where the webroot is located.

### Related

This PR works together with https://github.com/mautic/mautic/pull/17023 which adds auto-detection of `local_root` for internal Mautic path resolution.

---

## Changes

```json
{
  "extra": {
    "public-dir": "docroot",
    "mautic-scaffold": {
      "locations": {
        "web-root": "docroot/"
      }
    }
  }
}
```

Optionally, also update the `generate-assets` script to explicitly run `assets:install`:

```json
{
  "scripts": {
    "generate-assets": "@php bin/console mautic:assets:generate && @php bin/console assets:install --symlink --relative docroot/"
  }
}
```

---
### Steps to test this PR:

1. Clone this PR
2. Run `composer install`
3. Verify that `docroot/bundles/` contains Symfony bundle assets (not in `public/bundles/`)
4. Run `bin/console assets:install` manually and verify assets go to `docroot/bundles/`
5. Access `/api/v2/` endpoint and verify API documentation loads correctly (Swagger UI assets should be present)
